### PR TITLE
upgrade base image to quay.io/giantswarm/fluentd-kubernetes-daemonset:v1.14-debian-cloudwatch-1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,4 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Upgrade base image fluentd-kubernetes-daemonset v1.9.3-debian-cloudwatch-1.0 to v1.14-debian-cloudwatch-1
+
 [Unreleased]: https://github.com/giantswarm/REPOSITORY_NAME/tree/master

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/giantswarm/fluentd-kubernetes-daemonset:v1.9.3-debian-cloudwatch-1.0
+FROM quay.io/giantswarm/fluentd-kubernetes-daemonset:v1.14-debian-cloudwatch-1
 
 # Use root account to use apt
 USER root


### PR DESCRIPTION
Towards: giantswarm/giantswarm#20190

This PR attempt at fixing the (ahem) 1500 security vulnerabilities found. 

Upgrade outdated base image.

![image](https://user-images.githubusercontent.com/6536819/146222319-5b0f06cd-825e-4bc0-ac53-cd0ac6d2b236.png)
[source](https://grafana.g8s.gauss.eu-west-1.aws.gigantic.io/d/CK_Th9c7k/security-starboard-dashboard?orgId=1&viewPanel=13)