### PR TITLE
circleci: remove build job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,59 +2,18 @@ orbs:
   architect: giantswarm/architect@0.4.5
 
 version: 2.1
-jobs:
-  build:
-    machine: true
-    steps:
-    - checkout
-
-    - run: |
-        wget -q $(curl -sS -H "Authorization: token $RELEASE_TOKEN" https://api.github.com/repos/giantswarm/architect/releases/tags/v1.0.0 | grep browser_download_url | head -n 1 | cut -d '"' -f 4)
-        chmod +x ./architect
-        ./architect version
-
-    - run: |
-        date +"%Y" > /tmp/year
-        date +"%m" > /tmp/month
-        date +"%d" > /tmp/day
-    - restore_cache:
-        keys:
-        - go-cache-v1-{{ checksum "/tmp/year" }}-{{ checksum "/tmp/month" }}-{{ checksum "/tmp/day" }}
-        - go-cache-v1-{{ checksum "/tmp/year" }}-{{ checksum "/tmp/month" }}
-        - go-cache-v1-{{ checksum "/tmp/year" }}
-
-    - run: ./architect build
-
-    - store_test_results:
-        path: /tmp/results
-
-    - save_cache:
-        key: go-cache-v1-{{ checksum "/tmp/year" }}-{{ checksum "/tmp/month" }}-{{ checksum "/tmp/day" }}
-        paths:
-        - /tmp/go/cache
-
-    - persist_to_workspace:
-        root: .
-        paths:
-        - ./fluentd-cloudwatch-azure
-        - ./architect
 
 workflows:
   build:
     jobs:
-      - build
       - architect/push-to-docker-legacy:
           name: push-fluentd-cloudwatch-azure-to-quay
           image: "quay.io/giantswarm/fluentd-cloudwatch-azure"
           username_envar: "QUAY_USERNAME"
           password_envar: "QUAY_PASSWORD"
-          requires:
-            - build
 
       - hold-push-fluentd-cloudwatch-azure-to-aliyun-pr:
           type: approval
-          requires:
-            - build
           # Needed to prevent job from being triggered on master branch.
           filters:
             branches:
@@ -79,8 +38,6 @@ workflows:
           image: "registry-intl.cn-shanghai.aliyuncs.com/giantswarm/fluentd-cloudwatch-azure"
           username_envar: "ALIYUN_USERNAME"
           password_envar: "ALIYUN_PASSWORD"
-          requires:
-            - build
           # Needed to trigger job only on merge to master.
           filters:
             branches:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,4 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- CircleCI: removed deploy and build outdated jobs.
+
 [Unreleased]: https://github.com/giantswarm/REPOSITORY_NAME/tree/master


### PR DESCRIPTION
Towards: giantswarm/giantswarm#20190

Modernize CI and remove the old build job, which is redundant and also build docker images.