### PR TITLE
circleci: upgrade orb to 4.8.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,40 +1,50 @@
-orbs:
-  architect: giantswarm/architect@0.4.5
-
 version: 2.1
+
+orbs:
+  architect: giantswarm/architect@4.8.1
 
 workflows:
   build:
     jobs:
-      - architect/push-to-docker-legacy:
-          name: push-fluentd-cloudwatch-azure-to-quay
+      - architect/push-to-docker:
+          name: push-to-docker
+          context: "architect"
+          image: "docker.io/giantswarm/fluentd-cloudwatch-azure"
+          username_envar: "DOCKER_USERNAME"
+          password_envar: "DOCKER_PASSWORD"
+
+      - architect/push-to-docker:
+          name: push-to-quay
+          context: "architect"
           image: "quay.io/giantswarm/fluentd-cloudwatch-azure"
           username_envar: "QUAY_USERNAME"
           password_envar: "QUAY_PASSWORD"
 
-      - hold-push-fluentd-cloudwatch-azure-to-aliyun-pr:
+      - aliyun-approval:
           type: approval
           # Needed to prevent job from being triggered on master branch.
           filters:
             branches:
               ignore: master
 
-      - architect/push-to-docker-legacy:
-          name: push-fluentd-cloudwatch-azure-to-aliyun-pr
+      - architect/push-to-docker:
+          name: push-to-aliyun-pr
+          context: "architect"
           image: "registry-intl.cn-shanghai.aliyuncs.com/giantswarm/fluentd-cloudwatch-azure"
           username_envar: "ALIYUN_USERNAME"
           password_envar: "ALIYUN_PASSWORD"
           # Push to Aliyun should execute for non-master branches only once manually approved.
           requires:
-            - hold-push-fluentd-cloudwatch-azure-to-aliyun-pr
+            - aliyun-approval
           # Needed to prevent job being triggered for master branch.
           filters:
             branches:
               ignore: master
 
       # Push to Aliyun should execute without manual approval on master.
-      - architect/push-to-docker-legacy:
-          name: push-fluentd-cloudwatch-azure-to-aliyun-master
+      - architect/push-to-docker:
+          name: push-to-aliyun-master
+          context: "architect"
           image: "registry-intl.cn-shanghai.aliyuncs.com/giantswarm/fluentd-cloudwatch-azure"
           username_envar: "ALIYUN_USERNAME"
           password_envar: "ALIYUN_PASSWORD"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,5 +10,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - CircleCI: removed deploy and build outdated jobs.
+- CircleCI: upgrade orb 0.4.5 to 4.8.1
 
 [Unreleased]: https://github.com/giantswarm/REPOSITORY_NAME/tree/master

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,5 +11,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - CircleCI: removed deploy and build outdated jobs.
 - CircleCI: upgrade orb 0.4.5 to 4.8.1
+- CircleCI: push to docker.io
 
 [Unreleased]: https://github.com/giantswarm/REPOSITORY_NAME/tree/master


### PR DESCRIPTION
Towards: giantswarm/giantswarm#20190

Upgrade CircleCI orb and docker jobs, also pushes to docker.io registry.